### PR TITLE
Process the `mapping` as "additional" mapping

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -47,19 +47,17 @@ class {{classname}}(object):
 
     discriminator_value_class_map = {
         {{#children}}'{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}': '{{{classname}}}'{{^-last}},
-        {{/-last}}{{/children}}
+        {{/-last}}{{/children}}{{#mapping}},{{/mapping}}{{! TODO: Multi-level inheritance - Is there a way to include the children of the children here? }}
         {{^children}}
-            {{#mapping}}
-                {{#mappedModels}}
-        '{{mappingName}}': '{{modelName}}'{{^-last}},{{/-last}}
-                {{/mappedModels}}
-            {{/mapping}}
-            {{^mapping}}
-                {{#interfaces}}
-        '{{classname}}': '{{classname}}'{{^-last}},{{/-last}}
-                {{/interfaces}}
-            {{/mapping}}
+            {{#interfaces}}
+        '{{classname}}': '{{{classname}}}'{{^-last}},{{/-last}}{{#mapping}},{{/mapping}}
+            {{/interfaces}}
         {{/children}}
+        {{#mapping}}
+            {{#mappedModels}}
+        '{{mappingName}}': '{{{modelName}}}'{{^-last}},{{/-last}}
+            {{/mappedModels}}
+        {{/mapping}}
     }
 {{/discriminator}}
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Process the `mapping` as "additional" mapping instead of overriding `children` and `interfaces`.

Related to my comment on your PR: https://github.com/OpenAPITools/openapi-generator/pull/2170#issuecomment-469666702